### PR TITLE
Fixed a "local variable 'prefix' not associated with a value" bug

### DIFF
--- a/source/main/logs.py
+++ b/source/main/logs.py
@@ -483,7 +483,7 @@ class Logs:
 
                     if logging["LoggingEnabled"]["TargetPrefix"]:
                         prefix = logging["LoggingEnabled"]["TargetPrefix"]
-                    src_bucket = f"{src_bucket}|{prefix}"
+                        src_bucket = f"{src_bucket}|{prefix}"
 
                     self.results["s3"]["results"].append(src_bucket)
 


### PR DESCRIPTION
1. The original script was throwing an error during the "getting S3 logs" process whenever it encountered a bucket with no prefix value assigned. 
<img width="761" alt="1 Error" src="https://github.com/user-attachments/assets/fcf6c8b1-fae5-4bcd-9960-32964f2e09fc" />

2. Figured out that this was a result of the following code trying to assign the value of {prefix} outside the if-block. 
<img width="686" alt="0 ProblematicCode" src="https://github.com/user-attachments/assets/fd97c7b0-6e43-4085-986c-946359f0adc9" />

3. Even if the `if logging["LoggingEnabled"]["TargetPrefix"]` code didn't execute, line 486 tries to assign the `src_bucket` variable with the value of a non-existent `prefix`. 
4. Fixed the indentation so the line of code only executes if the if-block works. 
5. Log collection works again. 
<img width="596" alt="1 Fixed" src="https://github.com/user-attachments/assets/178a468f-5f29-47d2-9c70-456681bba82a" />
