### PR TITLE
Fix Windows-incompatible timestamp in analysis output path

### DIFF
--- a/source/main/analysis.py
+++ b/source/main/analysis.py
@@ -35,7 +35,7 @@ class Analysis:
 
         #new folder for each run
         now = datetime.datetime.now()
-        self.time = now.strftime("%H:%M:%S")
+        self.time = now.strftime("%H-%M-%S")
 
         if dl:
             self.path = ROOT_FOLDER + self.region + "/queries-results/"


### PR DESCRIPTION
Prevent WinError 123 by replacing ':' in directory names