### PR TITLE
Fix single-region mode using invalid 'not-all' region

### DIFF
--- a/invictus-aws.py
+++ b/invictus-aws.py
@@ -741,6 +741,7 @@ def verify_region_input(region_choice, region, steps):
                 first_region = "us-east-1"
         else:
             all_regions = verify_one_region(region)
+            first_region = region
     except IndexError:
         print(f"{ERROR} Please only enter valid region and follow the pattern needed.")
         sys.exit(-1)
@@ -954,3 +955,4 @@ def main():
 if __name__ == "__main__":
     main()
         
+


### PR DESCRIPTION
Ensure first_region is set when running in single-region mode.

Previously, first_region could remain set to the default "not-all", which later caused invalid AWS endpoints such as:
bucket.s3.not-all.amazonaws.com.