### PR TITLE
Fix log duplication when collecting all regions

### DIFF
--- a/source/main/logs.py
+++ b/source/main/logs.py
@@ -7,6 +7,7 @@ from json import loads, dumps
 from time import sleep
 from os import remove, rmdir
 from requests import get
+from copy import deepcopy
 
 import source.utils.utils
 from source.utils.utils import write_file, create_folder, copy_or_write_s3, create_command, writefile_s3, LOGS_RESULTS, create_s3_if_not_exists, LOGS_BUCKET, ROOT_FOLDER, set_clients, write_or_dl, write_s3, athena_query
@@ -33,7 +34,7 @@ class Logs:
         """
 
         self.region = region
-        self.results = LOGS_RESULTS
+        self.results = deepcopy(LOGS_RESULTS)
         self.dl = dl
 
         #Also created for cloudtrail-logs results


### PR DESCRIPTION
Currently when specifying `-A` the logs of earlier regions are duplicated to the later collected regions. In my case only the first region contained S3 logs, but all the output dirs contained the same content.

This was due to the reference `self.results = LOGS_RESULTS`, which results in every change on `self.result` also changing the `LOGS_RESULTS`. By doing a deepcopy of the dict the configuration dict stays the same for next iterations.